### PR TITLE
More generic asteroid handling

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ART/Asteroid.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ART/Asteroid.cfg
@@ -1,22 +1,28 @@
-@PART[PotatoRoid]
+@PART:HAS[@MODULE[ModuleAsteroid],!MODULE[USI_DynamicTank]]
 {
 	MODULE
 	{
 		name = USI_DynamicTank
 	}
+}
 	
+@PART:HAS[@MODULE[ModuleAsteroid],!MODULE[USI_AsteroidTank]]
+{
 	MODULE
 	{
 		name = USI_AsteroidTank
 	}
-	
+}
+
+@PART:HAS[@MODULE[ModuleAsteroid]]
+{
 	@MODULE[ModuleAsteroid]
 	{
-		density = 1.0  //Default is 0.03 so 33x more dense
+		@density *= 33.3333333333333  // Stock asteroids will have density of 1.0
 		maxRadiusMultiplier = 5.0  //Default is 1.25 so up to four times larger
 	}
 		
-	@density = 1.0 //Default is 0.03 so 33x more dense
+	@density *= 33.3333333333333  // Stock asteroids will have density of 1.0
 	
 }
 


### PR DESCRIPTION
I'm putting the finishing touches on an asteroid type system (Starstrider42/Custom-Asteroids#4) for Custom Asteroids. It would be helpful if other asteroid mods worked for any part containing `ModuleAsteroid`, not just `PotatoRoid`. This config file appears to be the only dependency on `PotatoRoid` in ART.