### PR TITLE
Fix remote URL of ART.version

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ART/ART.version
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ART/ART.version
@@ -1,6 +1,6 @@
 {
      "NAME":"Asteroid Recycling Tech",
-	 "URL":"https://raw.githubusercontent.com/BobPalmer/ART/master/FOR_RELEASE/GameData/ART/ART.version",
+	 "URL":"https://raw.githubusercontent.com/BobPalmer/ART/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/ART/ART.version",
 	 "DOWNLOAD":"https://github.com/BobPalmer/ART/releases",
      "GITHUB":{
          "USERNAME":"BobPalmer",
@@ -28,4 +28,4 @@
          "MINOR":8,
          "PATCH":9
      }
- } 
+ }


### PR DESCRIPTION
## Problem
The current value of the `URL` property of `ART.version` is a 404. I suspect the repo structure has changed some time ago.

## Changes
Change the URL to the current place of the `ART.version` file.

Pinging @BobPalmer since not everyone has pull request notifications enabled.

Also a shameless self-promotion:
I've written a small GitHub Action that you can add to this repository, which automatically validates the version files after pushes and in PRs, and warns in case of problems lie this:
https://github.com/DasSkelett/AVC-VersionFileValidator